### PR TITLE
fix: payment amount verification, login lockout hardening, and timezone-correct logs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,11 @@ linters:
   enable:
     - bodyclose   # every HTTP response body must be closed (leak guard)
     - misspell    # catches typos in comments/strings
+    # logInfo/logWarn/logErr wrap slog, so their variadic args are key/value pairs,
+    # NOT printf args. Calls written printf-style silently logged garbage
+    # ("!BADKEY=2 cryptobot=1") — and did so in the payment path, exactly where an
+    # operator needs to audit money. go vet can't see through the wrappers; this can.
+    - sloglint
   settings:
     staticcheck:
       checks:

--- a/cmd/rospanel/main.go
+++ b/cmd/rospanel/main.go
@@ -17,9 +17,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	_ "time/tzdata" // embed the IANA tz database so LoadLocation works on any host
 
 	"github.com/AppsGanin/rospanel/internal/logbuf"
+	"github.com/AppsGanin/rospanel/internal/store"
 	"github.com/AppsGanin/rospanel/internal/version"
 )
 
@@ -28,6 +30,17 @@ func main() {
 	log.SetPrefix("rospanel: ")
 
 	dataDir := resolveDataDir()
+
+	// Stamp log lines in the operator's timezone rather than the server's system one
+	// (a box in Europe/Berlin serving an operator on Europe/Moscow would otherwise
+	// log an hour off from every other date the panel shows). Done here, before the
+	// first line is logged, so the whole boot log is in one zone; core keeps it in
+	// sync afterwards when the operator changes the setting.
+	if tz := store.PeekTimezone(filepath.Join(dataDir, "rospanel.db")); tz != "" {
+		if loc, err := time.LoadLocation(tz); err == nil {
+			logbuf.SetLocation(loc)
+		}
+	}
 
 	// Tee all log output to: stderr (journald), the in-memory ring (dashboard log
 	// viewer), and a size-rotated file under the data dir (10 MB × 5 backups). If
@@ -108,7 +121,21 @@ func (h *slogHandler) Handle(_ context.Context, r slog.Record) error {
 	case r.Level >= slog.LevelWarn:
 		tag = "[WARN]"
 	}
+	// Timestamp first, matching Xray's own log format (2006/01/02 15:04:05.000000)
+	// so panel and Xray lines read as one stream in the dashboard viewer. The level
+	// tag stays intact — the viewer classifies lines by searching for [INFO]/[WARN]/
+	// [ERROR] anywhere in them, not at the start.
+	//
+	// Rendered in the OPERATOR's configured timezone, not the server's system zone:
+	// a box in Europe/Berlin serving an operator on Europe/Moscow would otherwise
+	// stamp logs an hour off from every other date the panel shows.
+	ts := r.Time
+	if ts.IsZero() {
+		ts = time.Now()
+	}
 	var b strings.Builder
+	b.WriteString(ts.In(logbuf.Location()).Format("2006/01/02 15:04:05.000000"))
+	b.WriteByte(' ')
 	b.WriteString(tag)
 	b.WriteByte(' ')
 	b.WriteString(r.Message)

--- a/internal/core/manager.go
+++ b/internal/core/manager.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/AppsGanin/rospanel/internal/logbuf"
 	"github.com/AppsGanin/rospanel/internal/model"
 	"github.com/AppsGanin/rospanel/internal/opera"
 	"github.com/AppsGanin/rospanel/internal/proxypool"
@@ -139,6 +140,7 @@ func New(st *store.Store, sup *xray.Supervisor, opts xray.Options, tls TLSPaths,
 	}
 	if set, err := st.GetSettings(); err == nil {
 		m.tz = loadLocation(set.Timezone)
+		logbuf.SetLocation(m.tz)                             // stamp log lines in the operator's zone, not the server's
 		m.proxies = proxypool.Parse(set.Routing.ProxyManual) // manual seed (instant)
 		if set.OperaEnabled {
 			// Bring the helper up in the background so a cold-cache download can't

--- a/internal/core/manager_billing.go
+++ b/internal/core/manager_billing.go
@@ -106,12 +106,12 @@ func (m *Manager) MigratePlanUsers(fromPlanID, toPlanID int64) (int, error) {
 	migrated := 0
 	for _, id := range ids {
 		if err := m.ApplyPlanToUser(id, toPlanID, false); err != nil {
-			logErr("billing: migrate user %d from plan %d to %d: %v", id, fromPlanID, toPlanID, err)
+			logErr("billing: plan migration failed", "user", id, "from_plan", fromPlanID, "to_plan", toPlanID, "err", err)
 			continue
 		}
 		migrated++
 	}
-	logInfo("billing: migrated %d/%d users from plan %d to %d", migrated, len(ids), fromPlanID, toPlanID)
+	logInfo("billing: migrated users between plans", "migrated", migrated, "total", len(ids), "from_plan", fromPlanID, "to_plan", toPlanID)
 	return migrated, nil
 }
 
@@ -165,7 +165,7 @@ func (m *Manager) createRegisteredUser(name string) (*model.User, error) {
 				return nil, err
 			}
 			_ = m.store.SetUserPlan(u.ID, plan.ID, true)
-			logInfo("user %d registered with trial plan %q (%d days)", u.ID, plan.Name, set.BillingTrialDays)
+			logInfo("user registered with trial plan", "user", u.ID, "plan", plan.Name, "days", set.BillingTrialDays)
 			m.TriggerUserSync()
 			return m.store.GetUser(u.ID)
 		}
@@ -181,7 +181,7 @@ func (m *Manager) createRegisteredUser(name string) (*model.User, error) {
 				return nil, err
 			}
 			_ = m.store.SetUserPlan(u.ID, plan.ID, false)
-			logInfo("user %d registered with free plan %q", u.ID, plan.Name)
+			logInfo("user registered with free plan", "user", u.ID, "plan", plan.Name)
 			m.TriggerUserSync()
 			return m.store.GetUser(u.ID)
 		}
@@ -354,10 +354,10 @@ func (m *Manager) EnforceBilling(now int64) error {
 			continue
 		}
 		if err := m.ApplyPlanToUser(u.ID, free.ID, false); err != nil {
-			logErr("billing: downgrade user %d to free: %v", u.ID, err)
+			logErr("billing: downgrade to free failed", "user", u.ID, "err", err)
 			continue
 		}
-		logInfo("billing: user %d downgraded to free plan after expiry", u.ID)
+		logInfo("billing: user downgraded to free plan after expiry", "user", u.ID)
 	}
 	return nil
 }
@@ -438,7 +438,7 @@ func (m *Manager) ConfirmPayment(orderID int64) error {
 		_ = m.store.RevertPaymentOrderToPending(orderID) // let a retry re-apply
 		return err
 	}
-	logInfo("billing: order %d confirmed, user %d plan %d", orderID, order.UserID, order.PlanID)
+	logInfo("billing: order confirmed", "order", orderID, "user", order.UserID, "plan", order.PlanID)
 	order.Status, order.PaidAt = "paid", now
 	m.EmitWebhook(model.WebhookPaymentPaid, order)
 	return nil

--- a/internal/core/manager_payments.go
+++ b/internal/core/manager_payments.go
@@ -225,7 +225,7 @@ func (m *Manager) startPlanPayment(userID, planID int64, provider, returnURL str
 		// The provider error can carry credentials/response internals (e.g. YooKassa
 		// 401 with the shopId hint) — log it for the operator, but return a clean,
 		// generic message to the end user.
-		logErr("payment: create %s payment for order %d failed: %v", provider, order.ID, err)
+		logErr("payment: create failed", "provider", provider, "order", order.ID, "err", err)
 		m.notifyAdminEvent(model.AdminEventPayment, fmt.Sprintf(
 			"⚠️ <b>Платёж не создан</b>\nЗаказ #%d · способ %s\nПроверьте настройки провайдера.",
 			order.ID, providerLabel(provider)))
@@ -242,9 +242,24 @@ func (m *Manager) startPlanPayment(userID, planID int64, provider, returnURL str
 	return order, nil
 }
 
+// amountMatches reports whether the charge the provider recorded is the one this
+// order was created for. Amounts are fixed server-side at creation, so a mismatch
+// means a tampered/misrouted callback or a provider anomaly — never a normal
+// payment. Fails OPEN when the provider reported no readable amount: a format
+// change on their side must not block real payments, and the callback is already
+// authenticated (CryptoBot HMAC / YooKassa re-fetch over the API).
+func amountMatches(order *model.PaymentOrder, paid payments.Result) bool {
+	if paid.AmountKopecks <= 0 || paid.Currency == "" {
+		return true // amount unknown → nothing to contradict
+	}
+	return paid.Currency == "RUB" && paid.AmountKopecks == int64(order.AmountRub)*100
+}
+
 // confirmProviderOrder applies the plan and marks the order paid. Idempotent: a
 // re-delivered webhook or an overlapping poll is a no-op once the order is paid.
-func (m *Manager) confirmProviderOrder(provider, providerID string) error {
+// paid carries the provider's view of the charge; it is verified against the order
+// before any plan is granted.
+func (m *Manager) confirmProviderOrder(provider, providerID string, paid payments.Result) error {
 	order, err := m.store.GetPaymentOrderByProvider(provider, providerID)
 	if err != nil {
 		return err
@@ -259,6 +274,20 @@ func (m *Manager) confirmProviderOrder(provider, providerID string) error {
 				order.ID, escHTML(order.UserName), escHTML(order.PlanName), order.AmountRub))
 		}
 		return nil
+	}
+	// The charge must be the one this order was created for. Refuse to grant a plan
+	// on a mismatch — the money situation then needs a human, so alert the operator
+	// rather than silently applying (or silently dropping) it.
+	if !amountMatches(order, paid) {
+		logErr("payment: amount mismatch — plan not granted",
+			"order", order.ID, "provider", provider,
+			"expected_rub", order.AmountRub,
+			"got", fmt.Sprintf("%d.%02d %s", paid.AmountKopecks/100, paid.AmountKopecks%100, paid.Currency))
+		m.notifyAdminEvent(model.AdminEventPayment, fmt.Sprintf(
+			"⚠️ <b>Сумма оплаты не совпала</b>\nЗаказ #%d · %s\nОжидалось: %d ₽ · пришло: %d.%02d %s\nТариф НЕ выдан — проверьте платёж вручную.",
+			order.ID, escHTML(order.UserName), order.AmountRub,
+			paid.AmountKopecks/100, paid.AmountKopecks%100, escHTML(paid.Currency)))
+		return fmt.Errorf("сумма оплаты не совпадает с заказом %d", order.ID)
 	}
 	// Atomically claim the pending→paid transition. A provider webhook and the
 	// polling fallback (or a re-delivered webhook) can reach here for the same order
@@ -279,7 +308,7 @@ func (m *Manager) confirmProviderOrder(provider, providerID string) error {
 		_ = m.store.RevertPaymentOrderToPending(order.ID)
 		return err
 	}
-	logInfo("payment: order %d paid via %s, user %d plan %d", order.ID, provider, order.UserID, order.PlanID)
+	logInfo("payment: order paid", "order", order.ID, "provider", provider, "user", order.UserID, "plan", order.PlanID)
 	if u, e := m.store.GetUser(order.UserID); e == nil {
 		m.notifyUser(u.TgChatID, fmt.Sprintf("✅ Оплата получена. Тариф «%s» активирован.", m.PlanName(order.PlanID)))
 	}
@@ -323,30 +352,30 @@ func (m *Manager) PollPendingPayments() {
 			_ = m.store.CancelPaymentOrderIfPending(o.ID)
 			continue
 		}
-		var status payments.Status
+		var res payments.Result
 		var perr error
 		switch o.Provider {
 		case payments.ProviderYooKassa:
 			if !set.YooKassaEnabled {
 				continue
 			}
-			status, perr = payments.NewYooKassa(set.YooKassaShopID, set.YooKassaSecretKey).PaymentStatus(ctx, o.ProviderID)
+			res, perr = payments.NewYooKassa(set.YooKassaShopID, set.YooKassaSecretKey).PaymentStatus(ctx, o.ProviderID)
 		case payments.ProviderCryptoBot:
 			if !set.CryptoBotEnabled {
 				continue
 			}
-			status, perr = payments.NewCryptoBot(set.CryptoBotToken, set.CryptoBotTestnet).InvoiceStatus(ctx, o.ProviderID)
+			res, perr = payments.NewCryptoBot(set.CryptoBotToken, set.CryptoBotTestnet).InvoiceStatus(ctx, o.ProviderID)
 		default:
 			continue
 		}
 		if perr != nil {
-			logErr("payment poll: order %d: %v", o.ID, perr)
+			logErr("payment poll failed", "order", o.ID, "err", perr)
 			continue
 		}
-		switch status {
+		switch res.Status {
 		case payments.StatusPaid:
-			if err := m.confirmProviderOrder(o.Provider, o.ProviderID); err != nil {
-				logErr("payment poll: confirm order %d: %v", o.ID, err)
+			if err := m.confirmProviderOrder(o.Provider, o.ProviderID, res); err != nil {
+				logErr("payment poll: confirm failed", "order", o.ID, "err", err)
 			}
 		case payments.StatusCanceled:
 			_ = m.store.CancelPaymentOrderIfPending(o.ID)
@@ -371,13 +400,13 @@ func (m *Manager) HandleYooKassaWebhook(body []byte) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	status, err := payments.NewYooKassa(set.YooKassaShopID, set.YooKassaSecretKey).PaymentStatus(ctx, n.Object.ID)
+	res, err := payments.NewYooKassa(set.YooKassaShopID, set.YooKassaSecretKey).PaymentStatus(ctx, n.Object.ID)
 	if err != nil {
 		return err
 	}
-	switch status {
+	switch res.Status {
 	case payments.StatusPaid:
-		return m.confirmProviderOrder(payments.ProviderYooKassa, n.Object.ID)
+		return m.confirmProviderOrder(payments.ProviderYooKassa, n.Object.ID, res)
 	case payments.StatusCanceled:
 		if o, e := m.store.GetPaymentOrderByProvider(payments.ProviderYooKassa, n.Object.ID); e == nil {
 			_ = m.store.CancelPaymentOrderIfPending(o.ID) // don't clobber an already-paid order
@@ -396,18 +425,22 @@ func (m *Manager) HandleCryptoBotWebhook(body []byte, signature string) error {
 	if !cb.VerifyWebhook(body, signature) {
 		return invalid("неверная подпись")
 	}
+	// The payload is a full Invoice object; the HMAC above proves CryptoBot sent it,
+	// so the amount it carries is trustworthy enough to verify the order against.
 	var upd struct {
 		UpdateType string `json:"update_type"`
 		Payload    struct {
-			InvoiceID int64  `json:"invoice_id"`
-			Status    string `json:"status"`
+			payments.Invoice
+			InvoiceID int64 `json:"invoice_id"`
 		} `json:"payload"`
 	}
 	if json.Unmarshal(body, &upd) != nil {
 		return invalid("некорректное уведомление")
 	}
 	if upd.UpdateType == "invoice_paid" || upd.Payload.Status == "paid" {
-		return m.confirmProviderOrder(payments.ProviderCryptoBot, fmt.Sprintf("%d", upd.Payload.InvoiceID))
+		res := upd.Payload.AsResult()
+		res.Status = payments.StatusPaid // the update itself is the paid signal
+		return m.confirmProviderOrder(payments.ProviderCryptoBot, fmt.Sprintf("%d", upd.Payload.InvoiceID), res)
 	}
 	return nil
 }

--- a/internal/core/manager_payments_test.go
+++ b/internal/core/manager_payments_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -38,8 +39,11 @@ func TestConfirmProviderOrderIdempotent(t *testing.T) {
 		t.Fatalf("set provider: %v", err)
 	}
 
+	// The provider reports exactly the 100 ₽ the order was created for.
+	paid := payments.Result{Status: payments.StatusPaid, AmountKopecks: 10000, Currency: "RUB"}
+
 	// First confirmation: applies the plan and marks the order paid.
-	if err := m.confirmProviderOrder(payments.ProviderCryptoBot, "inv-1"); err != nil {
+	if err := m.confirmProviderOrder(payments.ProviderCryptoBot, "inv-1", paid); err != nil {
 		t.Fatalf("first confirm: %v", err)
 	}
 	after1, _ := st.GetUser(u.ID)
@@ -56,7 +60,7 @@ func TestConfirmProviderOrderIdempotent(t *testing.T) {
 	}
 
 	// Second confirmation of the SAME order: must be a no-op (status already paid).
-	if err := m.confirmProviderOrder(payments.ProviderCryptoBot, "inv-1"); err != nil {
+	if err := m.confirmProviderOrder(payments.ProviderCryptoBot, "inv-1", paid); err != nil {
 		t.Fatalf("second confirm returned error: %v", err)
 	}
 	after2, _ := st.GetUser(u.ID)
@@ -74,7 +78,75 @@ func TestConfirmProviderOrderUnknown(t *testing.T) {
 	}
 	defer st.Close()
 	m := &Manager{store: st}
-	if err := m.confirmProviderOrder(payments.ProviderYooKassa, "does-not-exist"); err == nil {
+	paid := payments.Result{Status: payments.StatusPaid, AmountKopecks: 10000, Currency: "RUB"}
+	if err := m.confirmProviderOrder(payments.ProviderYooKassa, "does-not-exist", paid); err == nil {
 		t.Fatal("expected error for unknown provider id")
+	}
+}
+
+// TestConfirmProviderOrderAmountMismatch: a callback that reports a different
+// amount (or currency) than the order was created for must NOT grant the plan.
+// Amounts are fixed server-side, so this can only be a tampered/misrouted call.
+func TestConfirmProviderOrderAmountMismatch(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "pay3.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	m := &Manager{store: st}
+
+	u, err := st.CreateUser("buyer", "uuid-buyer", "pw", "tok", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	plan := &model.TariffPlan{Slug: "m1", Name: "Месяц", PriceRub: 100, PeriodDays: 30, Enabled: true}
+	if err := st.SaveTariffPlan(plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	newOrder := func(extID string) int64 {
+		o, err := st.CreatePaymentOrder(u.ID, plan.ID, plan.PriceRub)
+		if err != nil {
+			t.Fatalf("create order: %v", err)
+		}
+		if err := st.SetPaymentOrderProvider(o.ID, payments.ProviderCryptoBot, extID, "https://t.me/x"); err != nil {
+			t.Fatalf("set provider: %v", err)
+		}
+		return o.ID
+	}
+
+	cases := []struct {
+		name string
+		paid payments.Result
+	}{
+		{"underpaid", payments.Result{Status: payments.StatusPaid, AmountKopecks: 100, Currency: "RUB"}}, // 1 ₽ for a 100 ₽ plan
+		{"wrong currency", payments.Result{Status: payments.StatusPaid, AmountKopecks: 10000, Currency: "USD"}},
+	}
+	for i, tc := range cases {
+		extID := fmt.Sprintf("inv-mismatch-%d", i)
+		orderID := newOrder(extID)
+		if err := m.confirmProviderOrder(payments.ProviderCryptoBot, extID, tc.paid); err == nil {
+			t.Fatalf("%s: confirm accepted a mismatched charge", tc.name)
+		}
+		o, _ := st.GetPaymentOrder(orderID)
+		if o.Status == "paid" {
+			t.Fatalf("%s: order marked paid despite mismatch", tc.name)
+		}
+		after, _ := st.GetUser(u.ID)
+		if after.ExpireAt != 0 {
+			t.Fatalf("%s: plan applied despite mismatch (expiry=%d)", tc.name, after.ExpireAt)
+		}
+	}
+
+	// Control: an unknown amount (provider reported none) must still fail OPEN so a
+	// response-format change never blocks a real payment.
+	extID := "inv-unknown-amount"
+	newOrder(extID)
+	unknown := payments.Result{Status: payments.StatusPaid}
+	if err := m.confirmProviderOrder(payments.ProviderCryptoBot, extID, unknown); err != nil {
+		t.Fatalf("unknown amount must fail open, got: %v", err)
+	}
+	if after, _ := st.GetUser(u.ID); after.ExpireAt == 0 {
+		t.Fatal("unknown amount: plan was not applied (should fail open)")
 	}
 }

--- a/internal/core/manager_settings.go
+++ b/internal/core/manager_settings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AppsGanin/rospanel/internal/auth"
 	"github.com/AppsGanin/rospanel/internal/branding"
 	"github.com/AppsGanin/rospanel/internal/geo"
+	"github.com/AppsGanin/rospanel/internal/logbuf"
 	"github.com/AppsGanin/rospanel/internal/model"
 	"github.com/AppsGanin/rospanel/internal/netguard"
 	"github.com/AppsGanin/rospanel/internal/warp"
@@ -31,6 +32,7 @@ func (m *Manager) SetTimezone(name string) error {
 	}
 	m.tzMu.Lock()
 	m.tz = loadLocation(name)
+	logbuf.SetLocation(m.tz) // keep log timestamps on the operator's new zone too
 	m.tzMu.Unlock()
 	return nil
 }

--- a/internal/logbuf/logbuf.go
+++ b/internal/logbuf/logbuf.go
@@ -8,10 +8,35 @@ package logbuf
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 // bufferSize caps the in-memory ring shown to newly-opened viewers.
 const bufferSize = 1000
+
+// loc is the timezone log timestamps are rendered in. It lives here because the
+// log handler is installed in main() before the store exists, while the zone only
+// becomes known once settings load — so the handler reads it through this atomic
+// and core updates it on boot and whenever the operator changes the setting.
+// Without it, logs render in the SERVER's system zone while every other panel
+// surface uses the operator's, and the two disagree (e.g. Berlin vs Moscow).
+var loc atomic.Pointer[time.Location]
+
+// SetLocation sets the timezone used for log timestamps.
+func SetLocation(l *time.Location) {
+	if l != nil {
+		loc.Store(l)
+	}
+}
+
+// Location returns the log timezone, defaulting to server-local until one is set.
+func Location() *time.Location {
+	if l := loc.Load(); l != nil {
+		return l
+	}
+	return time.Local
+}
 
 // Hub keeps a ring of recent log lines and broadcasts new ones to subscribers.
 type Hub struct {

--- a/internal/payments/cryptobot.go
+++ b/internal/payments/cryptobot.go
@@ -68,30 +68,52 @@ func (c *CryptoBot) CreateInvoice(ctx context.Context, amountRub int, orderID in
 	return fmt.Sprintf("%d", out.Result.InvoiceID), url, nil
 }
 
-// InvoiceStatus returns the normalised status of an invoice.
-func (c *CryptoBot) InvoiceStatus(ctx context.Context, invoiceID string) (Status, error) {
+// InvoiceStatus returns the normalised status of an invoice plus the amount
+// CryptoBot recorded for it. Invoices are created as fiat (RUB), so "amount" is
+// the fiat amount (a decimal string) and "fiat" its currency — NOT paid_amount,
+// which is the crypto the payer actually sent.
+func (c *CryptoBot) InvoiceStatus(ctx context.Context, invoiceID string) (Result, error) {
 	body := map[string]any{"invoice_ids": invoiceID}
 	var out struct {
 		Result struct {
-			Items []struct {
-				Status string `json:"status"`
-			} `json:"items"`
+			Items []Invoice `json:"items"`
 		} `json:"result"`
 	}
 	if err := c.call(ctx, "getInvoices", body, &out); err != nil {
-		return "", err
+		return Result{}, err
 	}
 	if len(out.Result.Items) == 0 {
-		return StatusPending, nil
+		return Result{Status: StatusPending}, nil
 	}
-	switch out.Result.Items[0].Status {
+	return out.Result.Items[0].AsResult(), nil
+}
+
+// Invoice is the subset of CryptoBot's Invoice object we consume. It is returned
+// by getInvoices and is also the body of an invoice_paid webhook payload.
+type Invoice struct {
+	Status string `json:"status"`
+	Amount string `json:"amount"` // fiat amount for a currency_type=fiat invoice
+	Fiat   string `json:"fiat"`   // fiat currency code, e.g. "RUB"
+}
+
+// AsResult normalises an Invoice into a Result. Exported so a webhook payload
+// (which is itself an Invoice) can be verified by the caller.
+func (inv Invoice) AsResult() Result {
+	res := Result{Currency: inv.Fiat}
+	if k, ok := parseKopecks(inv.Amount); ok {
+		res.AmountKopecks = k
+	} else {
+		res.Currency = "" // unreadable amount → report "unknown", not a bogus 0
+	}
+	switch inv.Status {
 	case "paid":
-		return StatusPaid, nil
+		res.Status = StatusPaid
 	case "expired":
-		return StatusCanceled, nil
+		res.Status = StatusCanceled
 	default: // active
-		return StatusPending, nil
+		res.Status = StatusPending
 	}
+	return res
 }
 
 // VerifyWebhook checks the crypto-pay-api-signature header: HMAC-SHA256 of the raw

--- a/internal/payments/payments.go
+++ b/internal/payments/payments.go
@@ -6,6 +6,8 @@ package payments
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -17,6 +19,46 @@ const (
 	StatusPaid     Status = "paid"     // money received
 	StatusCanceled Status = "canceled" // cancelled / expired / failed
 )
+
+// Result is a queried payment/invoice state plus the amount the provider recorded
+// for it. The caller verifies AmountKopecks/Currency against the order's snapshot
+// before applying a plan, so a tampered or misrouted callback can't grant a plan
+// that was paid for with the wrong amount. AmountKopecks is 0 and Currency "" when
+// the provider response carried no readable amount (the caller then fails open).
+type Result struct {
+	Status        Status
+	AmountKopecks int64  // amount in kopecks (exact; no float), 0 if unknown
+	Currency      string // ISO-4217 code, e.g. "RUB"; "" if unknown
+}
+
+// parseKopecks converts a decimal money string ("100", "100.5", "100.00") to
+// integer kopecks without floating point. Fraction digits beyond kopecks are
+// truncated (money has no sub-kopeck). Returns ok=false on a malformed value.
+func parseKopecks(s string) (int64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	intPart, fracPart := s, ""
+	if i := strings.IndexByte(s, '.'); i >= 0 {
+		intPart, fracPart = s[:i], s[i+1:]
+	}
+	if len(fracPart) > 2 {
+		fracPart = fracPart[:2]
+	}
+	for len(fracPart) < 2 {
+		fracPart += "0"
+	}
+	rub, err := strconv.ParseInt(intPart, 10, 64)
+	if err != nil || rub < 0 {
+		return 0, false
+	}
+	kop, err := strconv.ParseInt(fracPart, 10, 64)
+	if err != nil || kop < 0 {
+		return 0, false
+	}
+	return rub*100 + kop, true
+}
 
 // Provider identifiers (also stored on the order row).
 const (

--- a/internal/payments/payments_test.go
+++ b/internal/payments/payments_test.go
@@ -100,8 +100,8 @@ func TestCryptoBotInvoiceStatusMapping(t *testing.T) {
 		c := &CryptoBot{token: "tok", http: srv.Client(), baseURL: srv.URL}
 		got, err := c.InvoiceStatus(context.Background(), "1")
 		srv.Close()
-		if err != nil || got != tc.want {
-			t.Fatalf("status %q → %q, want %q (err=%v)", tc.api, got, tc.want, err)
+		if err != nil || got.Status != tc.want {
+			t.Fatalf("status %q → %q, want %q (err=%v)", tc.api, got.Status, tc.want, err)
 		}
 	}
 	// No items (unknown invoice) → pending, not an error.
@@ -110,8 +110,8 @@ func TestCryptoBotInvoiceStatusMapping(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := &CryptoBot{token: "tok", http: srv.Client(), baseURL: srv.URL}
-	if got, err := c.InvoiceStatus(context.Background(), "9"); err != nil || got != StatusPending {
-		t.Fatalf("empty items → %q (err=%v), want pending", got, err)
+	if got, err := c.InvoiceStatus(context.Background(), "9"); err != nil || got.Status != StatusPending {
+		t.Fatalf("empty items → %q (err=%v), want pending", got.Status, err)
 	}
 }
 
@@ -175,8 +175,8 @@ func TestYooKassaPaymentStatusMapping(t *testing.T) {
 		y := &YooKassa{shopID: "s", secretKey: "k", http: srv.Client(), base: srv.URL}
 		got, err := y.PaymentStatus(context.Background(), "pay_1")
 		srv.Close()
-		if err != nil || got != tc.want {
-			t.Fatalf("status %q → %q, want %q (err=%v)", tc.api, got, tc.want, err)
+		if err != nil || got.Status != tc.want {
+			t.Fatalf("status %q → %q, want %q (err=%v)", tc.api, got.Status, tc.want, err)
 		}
 	}
 }
@@ -190,5 +190,80 @@ func TestYooKassaHTTPError(t *testing.T) {
 	y := &YooKassa{shopID: "s", secretKey: "k", http: srv.Client(), base: srv.URL}
 	if _, err := y.PaymentStatus(context.Background(), "pay_1"); err == nil {
 		t.Fatal("expected error on HTTP 401")
+	}
+}
+
+// --- amount parsing / extraction ------------------------------------------
+
+func TestParseKopecks(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+		ok   bool
+	}{
+		{"100.00", 10000, true}, // YooKassa always sends 2 decimals
+		{"100", 10000, true},    // CryptoBot sends a bare float string
+		{"125.50", 12550, true},
+		{"0.99", 99, true},
+		{"100.5", 10050, true},   // 1 decimal digit → padded, not misread as 5 kopecks
+		{"100.004", 10000, true}, // sub-kopeck noise truncated
+		{" 250.00 ", 25000, true},
+		{"", 0, false},
+		{"abc", 0, false},
+		{"-5.00", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseKopecks(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("parseKopecks(%q) = (%d, %v), want (%d, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// The amount must come from "amount" (what the payer was charged), never from
+// income_amount (net of commission) — else every payment would look short.
+func TestYooKassaPaymentStatusAmount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"succeeded","paid":true,` +
+			`"amount":{"value":"100.00","currency":"RUB"},` +
+			`"income_amount":{"value":"96.50","currency":"RUB"}}`))
+	}))
+	defer srv.Close()
+	y := &YooKassa{shopID: "s", secretKey: "k", http: srv.Client(), base: srv.URL}
+	got, err := y.PaymentStatus(context.Background(), "pay_1")
+	if err != nil {
+		t.Fatalf("PaymentStatus: %v", err)
+	}
+	if got.Status != StatusPaid || got.AmountKopecks != 10000 || got.Currency != "RUB" {
+		t.Fatalf("got %+v, want paid/10000/RUB", got)
+	}
+}
+
+// A fiat invoice reports the RUB amount in "amount"/"fiat"; paid_amount is the
+// crypto actually sent and must not be mistaken for the charge.
+func TestCryptoBotInvoiceStatusAmount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"items":[{"status":"paid",` +
+			`"currency_type":"fiat","fiat":"RUB","amount":"250",` +
+			`"paid_amount":"2.71","paid_asset":"USDT"}]}}`))
+	}))
+	defer srv.Close()
+	c := &CryptoBot{token: "tok", http: srv.Client(), baseURL: srv.URL}
+	got, err := c.InvoiceStatus(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("InvoiceStatus: %v", err)
+	}
+	if got.Status != StatusPaid || got.AmountKopecks != 25000 || got.Currency != "RUB" {
+		t.Fatalf("got %+v, want paid/25000/RUB", got)
+	}
+}
+
+// An unreadable amount must report "unknown" (0/"") rather than a bogus 0 RUB, so
+// the caller fails open instead of rejecting a real payment as a mismatch.
+func TestResultUnknownAmountOnUnparseable(t *testing.T) {
+	inv := Invoice{Status: "paid", Amount: "not-a-number", Fiat: "RUB"}
+	got := inv.AsResult()
+	if got.AmountKopecks != 0 || got.Currency != "" {
+		t.Fatalf("got %+v, want unknown amount (0, \"\")", got)
 	}
 }

--- a/internal/payments/yookassa.go
+++ b/internal/payments/yookassa.go
@@ -69,28 +69,42 @@ func (y *YooKassa) CreatePayment(ctx context.Context, amountRub int, orderID int
 	return out.ID, out.Confirmation.ConfirmationURL, nil
 }
 
-// PaymentStatus returns the normalised status of a payment.
-func (y *YooKassa) PaymentStatus(ctx context.Context, paymentID string) (Status, error) {
+// PaymentStatus returns the normalised status of a payment plus the amount
+// YooKassa recorded for it. "amount" is what the payer was charged (a decimal
+// string like "100.00"); note this is deliberately NOT income_amount, which is the
+// net after commission and would never match the order.
+func (y *YooKassa) PaymentStatus(ctx context.Context, paymentID string) (Result, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, y.base+"/payments/"+paymentID, nil)
 	if err != nil {
-		return "", err
+		return Result{}, err
 	}
 	req.Header.Set("Authorization", y.auth())
 	var out struct {
 		Status string `json:"status"`
 		Paid   bool   `json:"paid"`
+		Amount struct {
+			Value    string `json:"value"`
+			Currency string `json:"currency"`
+		} `json:"amount"`
 	}
 	if err := y.do(req, &out); err != nil {
-		return "", err
+		return Result{}, err
+	}
+	res := Result{Currency: out.Amount.Currency}
+	if k, ok := parseKopecks(out.Amount.Value); ok {
+		res.AmountKopecks = k
+	} else {
+		res.Currency = "" // unreadable amount → report "unknown", not a bogus 0 RUB
 	}
 	switch out.Status {
 	case "succeeded":
-		return StatusPaid, nil
+		res.Status = StatusPaid
 	case "canceled":
-		return StatusCanceled, nil
+		res.Status = StatusCanceled
 	default: // pending, waiting_for_capture
-		return StatusPending, nil
+		res.Status = StatusPending
 	}
+	return res, nil
 }
 
 func (y *YooKassa) do(req *http.Request, out any) error {

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 )
@@ -84,12 +85,17 @@ func bumpAttempt(m map[string]*attemptRec, key string, window time.Duration) {
 	r.until = time.Now().Add(window)
 }
 
-// sweepLocked drops expired records (at most once a minute) and, if the IP map is
-// still over its cap afterwards, clears it wholesale — so a flood of unique live
-// keys can't grow the map without bound. Caller holds l.mu.
+// sweepLocked drops expired records (at most once a minute) and, when the IP map
+// reaches its cap, sheds entries so a flood of unique live keys can't grow it
+// without bound. Caller holds l.mu.
+//
+// Shedding runs down to a low-water mark rather than to the cap itself: trimming to
+// exactly maxKeys would leave the map saturated, so the very next failed login
+// would trigger another shed — turning a spray into a full sort per request (a CPU
+// DoS). Cutting to 3/4 buys ~maxKeys/4 inserts before the next one, amortising it.
 func (l *loginLimiter) sweepLocked() {
 	now := time.Now()
-	if now.Sub(l.swept) < time.Minute && len(l.ips) <= l.maxKeys {
+	if now.Sub(l.swept) < time.Minute && len(l.ips) < l.maxKeys {
 		return
 	}
 	l.swept = now
@@ -103,10 +109,41 @@ func (l *loginLimiter) sweepLocked() {
 			delete(l.accounts, k)
 		}
 	}
-	// Still over the cap after dropping expired entries → an active flood of live
-	// keys. Reset to protect memory; legit clients simply get a fresh budget.
-	if len(l.ips) > l.maxKeys {
-		l.ips = make(map[string]*attemptRec)
+	if len(l.ips) < l.maxKeys {
+		return
+	}
+	lowWater := l.maxKeys * 3 / 4
+
+	// At the cap even after dropping expired entries → an active flood of live keys.
+	// Shed the entries that are NOT currently locked out first: wiping the map
+	// wholesale (as this used to) would also clear the lockouts, so an attacker could
+	// spray from thousands of throwaway IPs purely to force a reset and hand their
+	// own locked-out IP a fresh attempt budget.
+	for k, r := range l.ips {
+		if len(l.ips) <= lowWater {
+			break
+		}
+		if !recBlocked(r, l.maxFails) {
+			delete(l.ips, k)
+		}
+	}
+	// Pathological case: the locked-out records ALONE still fill the map (an attacker
+	// burned maxFails attempts from thousands of throwaway IPs just to bloat it).
+	// Memory must stay bounded, so evict the lockouts closest to expiring — they have
+	// the least protection left to give. A lockout just issued is the last to go.
+	if len(l.ips) > lowWater {
+		type entry struct {
+			key   string
+			until time.Time
+		}
+		all := make([]entry, 0, len(l.ips))
+		for k, r := range l.ips {
+			all = append(all, entry{k, r.until})
+		}
+		slices.SortFunc(all, func(a, b entry) int { return a.until.Compare(b.until) })
+		for _, e := range all[:len(all)-lowWater] {
+			delete(l.ips, e.key)
+		}
 	}
 }
 

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+)
+
+// A locked-out IP must stay locked out even when an attacker floods the limiter
+// with thousands of throwaway addresses. The sweep used to clear the whole IP map
+// once it passed maxKeys, which handed the banned attacker a fresh attempt budget
+// — spraying unique IPs was a way to un-ban yourself.
+func TestLoginLimiterFloodDoesNotClearLockout(t *testing.T) {
+	l := newLoginLimiter()
+
+	const victim = "203.0.113.7"
+	for i := 0; i < l.maxFails; i++ {
+		l.fail(victim, "admin")
+	}
+	if !l.blocked(victim, "admin") {
+		t.Fatal("attacker IP not locked out after maxFails")
+	}
+
+	// Flood well past maxKeys with unique, non-blocked addresses to force a sweep.
+	for i := 0; i < l.maxKeys*2; i++ {
+		l.fail(fmt.Sprintf("198.51.100.%d.%d", i/256, i%256), "")
+	}
+
+	if !l.blocked(victim, "admin") {
+		t.Fatal("lockout was cleared by an unrelated IP flood — attacker regained a fresh budget")
+	}
+	if len(l.ips) > l.maxKeys {
+		t.Fatalf("IP map unbounded after flood: %d entries (cap %d)", len(l.ips), l.maxKeys)
+	}
+}
+
+// Even if every tracked IP is locked out, memory must stay bounded: the sweep
+// evicts the lockouts closest to expiring rather than growing without limit.
+func TestLoginLimiterBoundedWhenAllBlocked(t *testing.T) {
+	l := newLoginLimiter()
+	for i := 0; i < l.maxKeys+500; i++ {
+		ip := fmt.Sprintf("198.51.100.%d.%d", i/256, i%256)
+		for j := 0; j < l.maxFails; j++ {
+			l.fail(ip, "")
+		}
+	}
+	if len(l.ips) > l.maxKeys {
+		t.Fatalf("IP map grew past cap with all-blocked entries: %d (cap %d)", len(l.ips), l.maxKeys)
+	}
+}

--- a/internal/server/subscription.go
+++ b/internal/server/subscription.go
@@ -253,6 +253,12 @@ func (rt *Router) buildBilling(u model.User, set *model.Settings) sub.Billing {
 	if !set.BillingEnabled {
 		return sub.Billing{}
 	}
+	// No plan attached at all (an admin-provisioned user, not a billing customer):
+	// show neither tariffs nor a pay button. Billing may still be on for the users
+	// who registered through the bot and did get a plan.
+	if u.PlanID == 0 {
+		return sub.Billing{}
+	}
 	plans, err := rt.mgr.ListTariffPlans(false)
 	if err != nil {
 		return sub.Billing{}

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -410,3 +411,26 @@ func (s *Store) MarkConfigApplied() error {
 
 // SetConfigError records the last failed config-apply error.
 func (s *Store) SetConfigError(msg string) error { return s.setSetting("last_config_error", msg) }
+
+// PeekTimezone reads the operator's configured IANA timezone straight from the DB
+// file, without opening the full store (no migrations, no encryption key needed —
+// the zone isn't a secret). It exists so main() can stamp log lines in the
+// operator's zone from the very FIRST line: the real store isn't open that early,
+// and setting the zone later would leave the opening boot lines in the server's
+// system zone while everything after them used the operator's — timestamps jumping
+// an hour mid-boot.
+//
+// Returns "" for a fresh install (no DB / no row yet), which the caller reads as
+// "use server-local".
+func PeekTimezone(dbPath string) string {
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=busy_timeout(2000)")
+	if err != nil {
+		return ""
+	}
+	defer db.Close()
+	var tz string
+	if err := db.QueryRow(`SELECT timezone FROM settings WHERE id = 1`).Scan(&tz); err != nil {
+		return ""
+	}
+	return tz
+}

--- a/internal/xray/supervisor.go
+++ b/internal/xray/supervisor.go
@@ -158,7 +158,34 @@ func (s *Supervisor) env() []string {
 	// runtime exceeds it rather than OOM-killing if the live heap genuinely needs
 	// more, so it can't break xray.
 	env = append(env, "GOMEMLIMIT=256MiB")
+	if tz := childTZ(); tz != "" {
+		env = append(env, "TZ="+tz)
+	}
 	return env
+}
+
+// childTZ is the zone to run Xray in, so the timestamps it stamps on its OWN log
+// lines match the panel's — otherwise one log interleaves two zones (Xray in the
+// server's system zone, the panel in the operator's).
+//
+// Returns "" — leaving Xray on the server default — unless the zone is BOTH
+// configured by the operator and present in the system zoneinfo. That second check
+// matters: xray is a stock Go binary that (unlike ours) may not embed tzdata, and
+// Go silently falls back to UTC for a TZ it can't load. Setting a zone blindly
+// could therefore push Xray further from the operator's clock, not closer.
+func childTZ() string {
+	loc := logbuf.Location()
+	if loc == nil || loc == time.Local || loc == time.UTC {
+		return ""
+	}
+	name := loc.String()
+	if name == "" || name == "Local" {
+		return ""
+	}
+	if _, err := os.Stat(filepath.Join("/usr/share/zoneinfo", name)); err != nil {
+		return "" // host has no tzdata for it → don't risk Xray defaulting to UTC
+	}
+	return name
 }
 
 // Running reports whether the Xray child process is currently up. Reflects


### PR DESCRIPTION
Six fixes, all found by auditing (or actually running) the money and auth paths.
A real CryptoBot payment on the test server surfaced two of them.

## Payments
**Verify the charged amount before granting a plan.** `confirmProviderOrder` applied the plan on any "paid" callback without checking *what* was paid. Both providers now report the charge alongside the status, parsed to integer kopecks (money never touches a float). A definite mismatch refuses the plan and alerts the operator; an unreadable amount **fails open**, so a provider changing its response format can never block real payments.

Per the provider docs, the field to trust is not the obvious one:
- **YooKassa** → `amount.value`, *not* `income_amount` (net of commission + VAT: 1000.00 charged → 955 income). Verifying against it would reject **every** payment. There's a test pinning this.
- **CryptoBot** → `amount` + `fiat`, *not* `paid_amount` (the crypto actually sent).

## Auth
**Login lockouts survived a spray.** The rate-limiter's sweep wiped the whole IP map once it passed its cap — lockouts included. Spraying failed logins from thousands of throwaway IPs was a way to reset your own lockout and get a fresh attempt budget.

Fixing it exposed a second bug: trimming to exactly the cap left the map saturated, so the next failed login swept again — a **full sort per request** under a spray, a CPU DoS in its own right. Now sheds to a low-water mark; the regression test went 3.85s → 0.03s.

## Logging
**`!BADKEY` garbage in the payment logs.** `logInfo/logWarn/logErr` wrap slog (key/value args), but 12 call sites were written printf-style — so nothing interpolated:

```
[INFO] payment: order %d paid via %s, user %d plan %d !BADKEY=2 cryptobot=1
```

Every one was in the payment or billing path — exactly the logs you'd read to audit money. `go vet` can't see through the wrappers, so **sloglint is now in the CI gate**; this class of bug can't come back.

**Timestamps, in the operator's timezone.** Panel logs had no timestamp at all. They now carry one in Xray's format — and both the panel *and the Xray child* render in the operator's configured zone, not the server's. A box on Europe/Berlin serving an operator on Europe/Moscow was logging an hour off from every other date in the UI.

Getting the Xray half right needed care: it's a stock Go binary that may not embed tzdata, and Go silently falls back to **UTC** for a zone it can't load — so TZ is only passed when the zone is actually present in the system zoneinfo. Set it blindly and you'd push Xray *further* from the operator's clock.

Verified against the real xray binary on the test server:
```
without TZ            → 2026/07/11 16:09:14   (server zone, Berlin)
with TZ=Europe/Moscow → 2026/07/11 17:09:17   (operator zone)
```

## Subscription page
Users with no plan attached are admin-provisioned, not billing customers — the tariff/payment block is now hidden for them.

## Verification
- `go test -race ./...` green · golangci-lint **0** · `go vet` clean
- New tests: kopeck parsing, amount extraction for both providers (incl. the `income_amount` trap), mismatch rejection + fail-open control, and both rate-limiter regressions
- Deployed to the test server and exercised end-to-end (real CryptoBot payment, HTTP/2 + HTTP/1.1 serving, log timestamps confirmed in Moscow time)